### PR TITLE
Milestone 0 — Bootstrap (v0.1.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,24 +5,32 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.12', '3.13' ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-      - name: Install dev deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install ruff black mypy pytest hypothesis pytest-benchmark
-      - name: Ruff
-        run: ruff check .
-      - name: Black (check)
-        run: black --check .
-      - name: Mypy
-        run: mypy src
-      - name: Pytest
-        run: pytest
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+      - name: Install dev deps (make)
+        run: make install-dev
+      - name: Quality gates (lint, type, tests)
+        run: make check
+      - name: Coverage gate
+        run: pytest --cov=fptk --cov-report=term-missing --cov-fail-under=90
+      - name: Package validity (build + twine check)
+        run: make build-check

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -15,11 +15,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Build sdist & wheel
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+      - name: Install build tool
         run: |
           python -m pip install --upgrade pip
           pip install build
-          python -m build
+      - name: Build sdist & wheel (Makefile)
+        run: make build
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Build sdist & wheel
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+      - name: Install build tool
         run: |
           python -m pip install --upgrade pip
           pip install build
-          python -m build
+      - name: Build sdist & wheel (Makefile)
+        run: make build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,8 @@ repos:
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.17.1
     hooks:
       - id: mypy
+        args: ["--config-file", "pyproject.toml"]
         additional_dependencies: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/README.md
+++ b/README.md
@@ -1,88 +1,96 @@
 # fptk
 
-Pragmatic functional programming helpers for Python.
+Pragmatic functional programming helpers for Python (3.12+). Small, explicit API with useful building blocks: function combinators, lightweight ADTs, lazy iterators, and applicative validation.
 
-## Why
-- Tiny, explicit API (no magic)
-- Ergonomic primitives: `pipe`, `compose`, `curry`, `tap`
+## Features
+- Tiny, explicit API (no magic or operator overloading)
+- Ergonomic function helpers: `pipe`, `compose`, `curry`, `flip`, `tap`, `thunk`
 - Lightweight ADTs: `Option`, `Result`, `NonEmptyList`
-- Lazy iterable combinators
-- Applicative validation that *accumulates* errors
+- Lazy iterator utilities: `map_iter`, `filter_iter`, `chunk`, `group_by_key`
+- Applicative validation (`validate_all`) that accumulates all errors
+- Strict typing (mypy --strict), clean style (ruff, black), and tests
 
 ## Install
 ```bash
 pip install fptk
-# or for development
+
+# Development install
 pip install -e .[dev]
 ```
 
+## Quick Start
+```python
+from fptk.core.func import pipe, compose, curry, tap
+from fptk.adt.option import Some, NONE, from_nullable
+from fptk.adt.result import Ok, Err
+from fptk.adt.nelist import NonEmptyList
+from fptk.iter.lazy import map_iter, filter_iter, chunk
+from fptk.validate import validate_all
+
+# Functions
+assert pipe(2, lambda x: x + 1, lambda x: x * 3) == 9
+inc_then_double = compose(lambda x: x * 2, lambda x: x + 1)
+assert inc_then_double(3) == 8
+
+# Option
+assert Some(2).map(lambda x: x + 1).get_or(0) == 3
+assert NONE.map(lambda x: x).get_or(42) == 42
+assert list(Some("a").iter()) == ["a"]
+
+# Result
+assert Ok(2).map(lambda x: x + 1).is_ok()
+assert Err("boom").map(lambda x: x).is_err()
+
+# NonEmptyList
+nel = NonEmptyList(1).append(2).append(3)
+assert list(nel) == [1, 2, 3]
+
+# Lazy iterators
+assert list(map_iter(lambda x: x + 1, [1, 2, 3])) == [2, 3, 4]
+assert list(filter_iter(lambda x: x % 2 == 0, [1, 2, 3, 4])) == [2, 4]
+assert list(chunk([1, 2, 3, 4, 5], 2)) == [(1, 2), (3, 4), (5,)]
+
+# Applicative validation
+def min_len(n: int):
+    def check(s: str):
+        return Ok(s) if len(s) >= n else Err(f"len<{n}")
+    return check
+
+def has_digit(s: str):
+    return Ok(s) if any(c.isdigit() for c in s) else Err("no digit")
+
+assert validate_all([min_len(3), has_digit], "ab3").is_ok()
+```
+
+## API Overview
+- `fptk.core.func`: `compose`, `pipe`, `curry`, `flip`, `tap`, `thunk`
+- `fptk.adt.option`: `Option[T]`, `Some[T]`, `None_`, `NONE`, `from_nullable`
+- `fptk.adt.result`: `Result[T, E]`, `Ok[T, E]`, `Err[T, E]`
+- `fptk.adt.nelist`: `NonEmptyList[E]`
+- `fptk.iter.lazy`: `map_iter`, `filter_iter`, `chunk`, `group_by_key`
+- `fptk.validate`: `validate_all`
+
+Public APIs are intentionally small; prefer explicit imports per module. See each module’s docstrings for usage details and examples.
+
+## Development
+This repo uses Makefile targets for common tasks:
+- Install dev env: `make install-dev`
+- Lint + types + tests: `make check`
+- Tests: `make test` or verbose `make Test-verbose`
+- Coverage: `make coverage`
+- Lint/format: `make lint` / `make format`
+- Build: `make build` / `make build-check`
+- Pre-commit: `make precommit-install` / `make precommit-run`
+
+Python 3.12+ is required. Type checking uses mypy `--strict` and code style uses ruff and black (line length 100).
+
 ## Contributing
 - Use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, ...)
-- Run `pre-commit install` 
-- `pytest -q` before PR
+- Run `make precommit-install` once; then `make precommit-run` locally
+- Ensure `make check` passes before opening a PR
 
-## 🗺️ Roadmap & Implementation Plan
+## Roadmap
+The roadmap has moved to `docs/ROADMAP.md`.
 
-### Principles
-- **Explicit over clever**: no operator overloading for core flows.
-- **Errors as values**: prefer `Result` for control flow; exceptions reserved for truly exceptional cases.
-- **Lazy by default** on iterables.
-- **Strict typing** and property-based tests for algebraic laws.
-
-### Milestone 0 — Bootstrap (v0.1.x)
-- Repo skeleton, tooling, CI, release automation, packaging
-- Minimal `core/func`, `Option`, `Result`, `NonEmptyList`, `lazy`, `validate_all`
-- Unit tests for each module
-
-**Acceptance**: CI green, `pip install -e .` works, `pytest` passes.
-
----
-
-### Milestone 1 — Utilities & Niceties (v0.2.x)
-- `core.func`: add `identity`, `const`, `once`, `try_catch(f) -> Result`
-- `adt.option`: `to_result(err)`, `or_else`, `match` helper
-- `adt.result`: `unwrap_or`, `unwrap_or_else`, `match` helper
-- `sequence`/`traverse` for `Option` and `Result`
-- Better `__repr__` for ADTs
-
-**Tests**: property-based tests for functor/monad laws (Hypothesis).
-
-**Docs**: examples showing `railway-oriented programming` patterns.
-
----
-
-### Milestone 2 — Async & Concurrency (v0.3.x)
-- `bind_async`/`map_async` variants for `Option`/`Result`
-- `gather_results(tasks) -> Result[list[T], E]` (fail-fast vs accumulate strategy)
-- `async_pipe` helper
-- Benchmarks vs naive asyncio patterns
-
-**Tests**: asyncio tests; ensure type inference stays sane.
-
----
-
-### Milestone 3 — Readers & State (v0.4.x)
-- `Reader[R, A]` for dependency injection
-- `State[S, A]` for pure stateful workflows
-- `Writer[W, A]` (monoidal log)
-- Combinators and examples (configuration loading, validation + enrichment)
-
-**Docs**: how to keep side effects at the edge; layering with `Result`.
-
----
-
-### Milestone 4 — Transformers & Interop (v0.5.x)
-- `OptionT`, `ResultT` transformers
-- Interop helpers for popular libs (e.g., mapping Exceptions→`Err`)
-- Optional `parse` combinators for text/HTTP inputs
-
-**Perf**: micro-benchmarks, flamegraphs for hot paths.
-
----
-
-### Milestone 5 — v1.0.0 (API freeze)
-- Audit public surface; deprecate rough edges
-- Documentation site with narrative guides and recipes
-- Stability guarantee and semver promise
-
-**Release criteria**: 100% typed, 95%+ unit coverage on core modules, clear migration notes from 0.x.
+## License
+MIT — see `LICENSE`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,66 @@
+# Roadmap & Implementation Plan
+
+## Principles
+- Explicit over clever: no operator overloading for core flows.
+- Errors as values: prefer `Result` for control flow; exceptions reserved for truly exceptional cases.
+- Lazy by default on iterables.
+- Strict typing and property-based tests for algebraic laws.
+
+## Milestone 0 — Bootstrap (v0.1.x)
+- Repo skeleton, tooling, CI, release automation, packaging
+- Minimal `core/func`, `Option`, `Result`, `NonEmptyList`, lazy iterators, `validate_all`
+- Unit tests for each module
+
+Acceptance: CI green, `pip install -e .` works, `pytest` passes.
+
+---
+
+## Milestone 1 — Utilities & Niceties (v0.2.x)
+- `core.func`: `identity`, `const`, `once`, `try_catch(f) -> Result`
+- `adt.option`: `to_result(err)`, `or_else`, `match` helper
+- `adt.result`: `unwrap_or`, `unwrap_or_else`, `match` helper
+- `sequence`/`traverse` for `Option` and `Result`
+- Better `__repr__` for ADTs
+
+Tests: property-based tests for functor/monad laws (Hypothesis).
+
+Docs: examples showing railway-oriented programming patterns.
+
+---
+
+## Milestone 2 — Async & Concurrency (v0.3.x)
+- `bind_async`/`map_async` variants for `Option`/`Result`
+- `gather_results(tasks) -> Result[list[T], E]` (fail-fast vs accumulate strategy)
+- `async_pipe` helper
+- Benchmarks vs naive asyncio patterns
+
+Tests: asyncio tests; ensure type inference stays sane.
+
+---
+
+## Milestone 3 — Readers & State (v0.4.x)
+- `Reader[R, A]` for dependency injection
+- `State[S, A]` for pure stateful workflows
+- `Writer[W, A]` (monoidal log)
+- Combinators and examples (configuration loading, validation + enrichment)
+
+Docs: how to keep side effects at the edge; layering with `Result`.
+
+---
+
+## Milestone 4 — Transformers & Interop (v0.5.x)
+- `OptionT`, `ResultT` transformers
+- Interop helpers for popular libs (e.g., mapping Exceptions → `Err`)
+- Optional `parse` combinators for text/HTTP inputs
+
+Perf: micro-benchmarks, flamegraphs for hot paths.
+
+---
+
+## Milestone 5 — v1.0.0 (API freeze)
+- Audit public surface; deprecate rough edges
+- Documentation site with narrative guides and recipes
+- Stability guarantee and semver promise
+
+Release criteria: 100% typed, 95%+ unit coverage on core modules, clear migration notes from 0.x.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Changelog = "https://github.com/mhbxyz/fptk/releases"
 line-length = 100
 target-version = "py312"
 lint.select = ["E", "F", "I", "UP", "B", "ANN", "PL"]
+lint.ignore = ["ANN101"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["ANN"]

--- a/src/fptk/adt/nelist.py
+++ b/src/fptk/adt/nelist.py
@@ -1,0 +1,61 @@
+"""Non-empty list (NonEmptyList) — a list with at least one element.
+
+This minimal ADT guarantees non-emptiness by construction with a ``head`` and
+an optional ``tail`` tuple. It supports iteration in order, ``append`` to add an
+element at the end, and a ``from_iter`` constructor that returns ``None`` for an
+empty input iterable.
+
+Examples:
+
+    >>> from fptk.adt.nelist import NonEmptyList
+    >>> nel = NonEmptyList(1).append(2).append(3)
+    >>> list(nel)
+    [1, 2, 3]
+    >>> NonEmptyList.from_iter(["a", "b"]).head
+    'a'
+    >>> NonEmptyList.from_iter([]) is None
+    True
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from typing import TypeVar
+
+__all__ = [
+    "NonEmptyList",
+]
+
+E = TypeVar("E")
+
+
+@dataclass(frozen=True, slots=True)
+class NonEmptyList[E]:
+    """A simple, immutable non-empty list with ``head`` and ``tail``.
+
+    - ``head``: first element (guarantees non-emptiness)
+    - ``tail``: zero-or-more remaining elements stored as a tuple
+    """
+
+    head: E
+    tail: tuple[E, ...] = ()
+
+    def __iter__(self) -> Iterator[E]:
+        """Iterate from ``head`` through all elements in ``tail``."""
+        yield self.head
+        yield from self.tail
+
+    def append(self, e: E) -> NonEmptyList[E]:
+        """Return a new list with ``e`` appended at the end."""
+        return NonEmptyList(self.head, self.tail + (e,))
+
+    @staticmethod
+    def from_iter(it: Iterable[E]) -> NonEmptyList[E] | None:
+        """Build a ``NonEmptyList`` from an iterable, or ``None`` if empty."""
+        iterator = iter(it)
+        try:
+            h = next(iterator)
+        except StopIteration:
+            return None
+        return NonEmptyList(h, tuple(iterator))

--- a/src/fptk/adt/option.py
+++ b/src/fptk/adt/option.py
@@ -1,0 +1,111 @@
+"""Option (Some/_None) — a lightweight optional type.
+
+This module provides a tiny, typed alternative to using ``None`` directly. The
+``Option[T]`` algebraic data type has two variants:
+
+- ``Some(value)``: wraps a present value of type ``T``
+- ``_None`` (singleton ``NONE``): represents the absence of a value
+
+Core operations are ``map`` (transform the contained value), ``bind`` (monadic
+flat-map), ``get_or`` (provide a default), and ``iter`` (iterate over zero-or-one
+values). All variants are immutable and hashable.
+
+Examples:
+
+    >>> from fptk.adt.option import Some, NONE, from_nullable
+    >>> Some(2).map(lambda x: x + 1).get_or(0)
+    3
+    >>> NONE.map(lambda x: x + 1).get_or(0)
+    0
+    >>> from_nullable("x").bind(lambda s: Some(s.upper())).get_or("-")
+    'X'
+
+Prefer constructing options explicitly via ``Some``/``NONE`` or ``from_nullable``
+when turning ``T | None`` into ``Option[T]``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import TypeVar, cast
+
+__all__ = [
+    "Option",
+    "Some",
+    "NONE",
+    "from_nullable",
+]
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class Option[T]:
+    """Optional value container with ``Some``/``_None`` variants.
+
+    Instances are either ``Some[T]`` or the ``NONE`` singleton. Use the
+    provided combinators to transform and consume values without branching.
+    """
+
+    def is_some(self) -> bool:
+        """Return ``True`` if this is ``Some``.
+
+        Subclasses implement this; calling on the base type is not expected.
+        """
+        raise NotImplementedError
+
+    def is_none(self) -> bool:
+        """Return ``True`` if this is ``NONE`` (i.e., not ``Some``)."""
+        return not self.is_some()
+
+    def map(self, f: Callable[[T], U]) -> Option[U]:
+        """Apply ``f`` to the contained value if ``Some``; otherwise ``NONE``.
+
+        Mapping preserves the optional nature: ``Some(x).map(f)`` becomes
+        ``Some(f(x))``; ``NONE.map(f)`` stays ``NONE``.
+        """
+        return Some(f(self.value)) if isinstance(self, Some) else cast(Option[U], NONE)
+
+    def bind(self, f: Callable[[T], Option[U]]) -> Option[U]:
+        """Flat-map with ``f`` returning another ``Option``.
+
+        Also known as ``and_then``/``flat_map``.
+        """
+        return f(self.value) if isinstance(self, Some) else cast(Option[U], NONE)
+
+    def get_or(self, default: U) -> T | U:
+        """Unwrap the value or return ``default`` if ``NONE``."""
+        return self.value if isinstance(self, Some) else default
+
+    def iter(self) -> Iterator[T]:
+        """Iterate over zero-or-one items (``Some`` yields one element)."""
+        if isinstance(self, Some):
+            yield self.value
+
+
+@dataclass(frozen=True, slots=True)
+class Some[T](Option[T]):
+    value: T
+
+    def is_some(self) -> bool:
+        """``Some`` always reports presence of a value."""
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class _None(Option[None]):
+    def is_some(self) -> bool:
+        """``_None`` always reports absence of a value."""
+        return False
+
+
+NONE = _None()
+
+
+def from_nullable[T](x: T | None) -> Option[T]:
+    """Convert a ``T | None`` into ``Option[T]``.
+
+    Returns ``Some(x)`` when ``x`` is not ``None``; otherwise ``NONE``.
+    """
+    return cast(Option[T], NONE) if x is None else Some(x)

--- a/src/fptk/adt/result.py
+++ b/src/fptk/adt/result.py
@@ -1,0 +1,89 @@
+"""Result (Ok/Err) — success or failure with typed error.
+
+The ``Result[T, E]`` algebraic data type represents computations that may
+succeed with a value of type ``T`` or fail with an error of type ``E``:
+
+- ``Ok(value)``: success variant wrapping a value ``T``
+- ``Err(error)``: failure variant wrapping an error ``E``
+
+Combinators include ``map`` (transform success), ``bind`` (flat-map), and
+``map_err`` (transform error), allowing ergonomic composition without ``try``/``except``.
+
+Examples:
+
+    >>> from fptk.adt.result import Ok, Err
+    >>> Ok(2).map(lambda x: x + 1)
+    Ok(value=3)
+    >>> Err("boom").map(lambda x: x + 1)
+    Err(error='boom')
+    >>> Ok("7").bind(lambda s: Ok(int(s)))
+    Ok(value=7)
+    >>> Err("boom").map_err(lambda s: s.upper())
+    Err(error='BOOM')
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeVar, cast
+
+__all__ = [
+    "Result",
+    "Ok",
+    "Err",
+]
+
+T = TypeVar("T")
+E = TypeVar("E")
+U = TypeVar("U")
+
+
+class Result[T, E]:
+    """Computation that may succeed (``Ok``) or fail (``Err``)."""
+
+    def is_ok(self) -> bool:
+        """Return ``True`` if this is ``Ok``."""
+        raise NotImplementedError
+
+    def is_err(self) -> bool:
+        """Return ``True`` if this is ``Err`` (not ``Ok``)."""
+        return not self.is_ok()
+
+    def map(self, f: Callable[[T], U]) -> Result[U, E]:
+        """Transform the success value with ``f``; preserve errors.
+
+        ``Ok(x).map(f)`` becomes ``Ok(f(x))``; ``Err(e)`` stays ``Err(e)``.
+        """
+        return Ok(f(self.value)) if isinstance(self, Ok) else cast(Result[U, E], self)
+
+    def bind(self, f: Callable[[T], Result[U, E]]) -> Result[U, E]:
+        """Flat-map with ``f`` returning another ``Result``.
+
+        Also known as ``and_then``/``flat_map``.
+        """
+        return f(self.value) if isinstance(self, Ok) else cast(Result[U, E], self)
+
+    def map_err(self, f: Callable[[E], U]) -> Result[T, U]:
+        """Transform the error with ``f``; preserve successes."""
+        return Err(f(self.error)) if isinstance(self, Err) else cast(Result[T, U], self)
+
+
+@dataclass(frozen=True, slots=True)
+class Ok[T, E](Result[T, E]):
+    """Success variant wrapping a value ``T``."""
+
+    value: T
+
+    def is_ok(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class Err[T, E](Result[T, E]):
+    """Failure variant wrapping an error ``E``."""
+
+    error: E
+
+    def is_ok(self) -> bool:
+        return False

--- a/src/fptk/core/func.py
+++ b/src/fptk/core/func.py
@@ -1,7 +1,40 @@
+"""Core function combinators: compose, pipe, curry, flip, tap, thunk.
+
+These helpers provide small, pragmatic building blocks for a functional style.
+
+- ``compose(f, g)``: build a new function ``x -> f(g(x))``
+- ``pipe(x, *fs)``: thread a value through a sequence of unary functions
+- ``curry(fn)``: turn an N-arg function into nested unary functions
+- ``flip(fn)``: swap the first two arguments of a binary function
+- ``tap(f)``: run a side-effect on a value and return the value
+- ``thunk(f)``: memoized nullary function (simple lazy evaluation)
+
+Examples:
+    >>> from fptk.core.func import compose, pipe, curry, flip, tap, thunk
+    >>> pipe(2, lambda x: x + 1, lambda x: x * 3)
+    9
+    >>> inc_then_double = compose(lambda x: x * 2, lambda x: x + 1)
+    >>> inc_then_double(3)
+    8
+    >>> add = lambda a, b: a + b
+    >>> add_curried = curry(add)
+    >>> add_curried(2)(3)
+    5
+"""
+
 from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any, ParamSpec, TypeVar
+
+__all__ = [
+    "compose",
+    "pipe",
+    "curry",
+    "flip",
+    "tap",
+    "thunk",
+]
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/src/fptk/core/func.py
+++ b/src/fptk/core/func.py
@@ -47,3 +47,13 @@ def flip(fn: Callable[[T, U], V]) -> Callable[[U, T], V]:  # noqa: UP047
         return fn(a, b)
 
     return flipped
+
+
+def tap(f: Callable[[T], Any]) -> Callable[[T], T]:  # noqa: UP047
+    """Run a side effect on a value and return the original value."""
+
+    def inner(x: T) -> T:
+        f(x)
+        return x
+
+    return inner

--- a/src/fptk/core/func.py
+++ b/src/fptk/core/func.py
@@ -38,3 +38,12 @@ def curry(fn: Callable[P, T]) -> Callable[..., Any]:  # noqa: UP047
         return lambda *a, **k: curried(*(args + a), **{**kwargs, **k})
 
     return curried
+
+
+def flip(fn: Callable[[T, U], V]) -> Callable[[U, T], V]:  # noqa: UP047
+    """Flip the first two arguments of a binary function."""
+
+    def flipped(b: U, a: T) -> V:
+        return fn(a, b)
+
+    return flipped

--- a/src/fptk/core/func.py
+++ b/src/fptk/core/func.py
@@ -57,3 +57,18 @@ def tap(f: Callable[[T], Any]) -> Callable[[T], T]:  # noqa: UP047
         return x
 
     return inner
+
+
+def thunk(f: Callable[[], T]) -> Callable[[], T]:  # noqa: UP047
+    """Memoized nullary function (simple lazy thunk)."""
+    evaluated = False
+    value: T | None = None
+
+    def wrapper() -> T:
+        nonlocal evaluated, value
+        if not evaluated:
+            value = f()
+            evaluated = True
+        return value  # type: ignore[return-value]
+
+    return wrapper

--- a/src/fptk/iter/lazy.py
+++ b/src/fptk/iter/lazy.py
@@ -1,0 +1,74 @@
+"""Small lazy iterator helpers: map, filter, chunk, group_by_key.
+
+These utilities compose well with Python iterables while remaining lazy where
+possible.
+
+- ``map_iter(f, xs)``: lazily map a transformation over items
+- ``filter_iter(pred, xs)``: lazily filter items by a predicate
+- ``chunk(xs, size)``: yield fixed-size tuples until exhaustion
+- ``group_by_key(xs, key)``: group consecutive items by key (input must be sorted)
+
+Examples:
+    >>> from fptk.iter.lazy import map_iter, filter_iter, chunk, group_by_key
+    >>> list(map_iter(lambda x: x + 1, [1, 2, 3]))
+    [2, 3, 4]
+    >>> list(filter_iter(lambda x: x % 2 == 0, [1, 2, 3, 4]))
+    [2, 4]
+    >>> list(chunk([1, 2, 3, 4, 5], 2))
+    [(1, 2), (3, 4), (5,)]
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from itertools import groupby, islice
+from typing import TypeVar
+
+__all__ = [
+    "map_iter",
+    "filter_iter",
+    "chunk",
+    "group_by_key",
+]
+
+T = TypeVar("T")
+K = TypeVar("K")
+
+
+def map_iter[T, K](f: Callable[[T], K], xs: Iterable[T]) -> Iterator[K]:
+    """Lazily apply ``f`` to each item of ``xs``.
+
+    Equivalent to ``map(f, xs)`` but typed with explicit iterator output.
+    """
+    for x in xs:
+        yield f(x)
+
+
+def filter_iter[T](pred: Callable[[T], bool], xs: Iterable[T]) -> Iterator[T]:
+    """Lazily yield items of ``xs`` for which ``pred(item)`` is true."""
+    for x in xs:
+        if pred(x):
+            yield x
+
+
+def chunk[T](xs: Iterable[T], size: int) -> Iterator[tuple[T, ...]]:
+    """Yield tuples of up to ``size`` items from ``xs``.
+
+    The final chunk may be shorter if items do not divide evenly. Preserves
+    ``None`` values in the input.
+    """
+    it = iter(xs)
+    while True:
+        buf = tuple(islice(it, size))
+        if not buf:
+            return
+        yield buf
+
+
+def group_by_key[T, K](xs: Iterable[T], key: Callable[[T], K]) -> Iterator[tuple[K, list[T]]]:
+    """Group consecutive items by ``key``; requires input pre-sorted by ``key``.
+
+    Each group is realized as a list for convenience.
+    """
+    for k, grp in groupby(xs, key=key):
+        yield k, list(grp)

--- a/src/fptk/validate.py
+++ b/src/fptk/validate.py
@@ -34,9 +34,9 @@ T = TypeVar("T")
 E = TypeVar("E")
 
 
-def validate_all[
-    T, E
-](checks: Iterable[Callable[[T], Result[T, E]]], value: T) -> Result[T, NonEmptyList[E]]:
+def validate_all[T, E](
+    checks: Iterable[Callable[[T], Result[T, E]]], value: T
+) -> Result[T, NonEmptyList[E]]:
     """Run checks on ``value`` and accumulate all errors.
 
     - On success for all checks, returns ``Ok`` with the (possibly transformed)

--- a/src/fptk/validate.py
+++ b/src/fptk/validate.py
@@ -1,0 +1,56 @@
+"""Validation helpers that accumulate errors applicatively.
+
+This module provides ``validate_all``, a combinator that runs multiple
+validation checks on a value and collects all error messages using the
+``NonEmptyList`` ADT instead of failing fast. It composes over ``Result`` so it
+fits naturally with other success/failure pipelines.
+
+Example:
+    >>> from fptk.validate import validate_all
+    >>> from fptk.adt.result import Ok, Err
+    >>> def min_len(n: int):
+    ...     def check(s: str):
+    ...         return Ok(s) if len(s) >= n else Err(f"len<{n}")
+    ...     return check
+    >>> def has_digit(s: str):
+    ...     return Ok(s) if any(c.isdigit() for c in s) else Err("no digit")
+    >>> validate_all([min_len(3), has_digit], "ab3").is_ok()
+    True
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+from fptk.adt.nelist import NonEmptyList
+from fptk.adt.result import Err, Ok, Result
+
+__all__ = [
+    "validate_all",
+]
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+def validate_all[
+    T, E
+](checks: Iterable[Callable[[T], Result[T, E]]], value: T) -> Result[T, NonEmptyList[E]]:
+    """Run checks on ``value`` and accumulate all errors.
+
+    - On success for all checks, returns ``Ok`` with the (possibly transformed)
+      value.
+    - On any failure, returns ``Err`` with a ``NonEmptyList`` of all collected
+      errors in order.
+    """
+    errors: NonEmptyList[E] | None = None
+    cur = value
+    for check in checks:
+        r = check(cur)
+        if isinstance(r, Ok):
+            cur = r.value
+        elif isinstance(r, Err):
+            err = r.error
+            errors = NonEmptyList(err) if errors is None else errors.append(err)
+    return Ok(cur) if errors is None else Err(errors)

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fptk.core.func import compose, curry, flip, pipe, tap
+from fptk.core.func import compose, curry, flip, pipe, tap, thunk
 
 # avoid magic number (PLR2004)
 EIGHT = 8
@@ -53,3 +53,19 @@ def test_tap() -> None:
     tapped = tap(record)
     assert tapped(42) == FORTY_TWO
     assert out == [42]
+
+
+def test_thunk_memoizes_and_runs_once() -> None:
+    calls = {"n": 0}
+
+    def compute() -> int:
+        calls["n"] += 1
+        return FORTY_TWO
+
+    lazy = thunk(compute)
+    # First call evaluates and returns value
+    assert lazy() == FORTY_TWO
+    # Subsequent calls return cached value without re-running compute
+    assert lazy() == FORTY_TWO
+    assert lazy() == FORTY_TWO
+    assert calls["n"] == 1

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from fptk.core.func import compose, curry, flip, pipe
+from fptk.core.func import compose, curry, flip, pipe, tap
 
 # avoid magic number (PLR2004)
 EIGHT = 8
 SIX = 6
 THREE = 3
+FORTY_TWO = 42
 
 
 def inc(x: int) -> int:
@@ -41,3 +42,14 @@ def test_flip() -> None:
     flipped = flip(sub)
     assert sub(5, 2) == THREE
     assert flipped(5, 2) == -THREE
+
+
+def test_tap() -> None:
+    out: list[int] = []
+
+    def record(x: int) -> None:
+        out.append(x)
+
+    tapped = tap(record)
+    assert tapped(42) == FORTY_TWO
+    assert out == [42]

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from fptk.core.func import compose, curry, pipe
+from fptk.core.func import compose, curry, flip, pipe
 
-EXPECTED = 8  # avoid magic number (PLR2004)
-SIX = 6  # avoid magic number (PLR2004)
+# avoid magic number (PLR2004)
+EIGHT = 8
+SIX = 6
+THREE = 3
 
 
 def inc(x: int) -> int:
@@ -15,11 +17,11 @@ def dbl(x: int) -> int:
 
 
 def test_compose() -> None:
-    assert compose(dbl, inc)(3) == EXPECTED
+    assert compose(dbl, inc)(3) == EIGHT
 
 
 def test_pipe() -> None:
-    assert pipe(3, inc, dbl) == EXPECTED
+    assert pipe(3, inc, dbl) == EIGHT
 
 
 def test_curry() -> None:
@@ -30,3 +32,12 @@ def test_curry() -> None:
     assert add3(1)(2)(3) == SIX
     assert add3(1, 2)(3) == SIX
     assert add3(1)(2, 3) == SIX
+
+
+def test_flip() -> None:
+    def sub(a: int, b: int) -> int:  # a - b
+        return a - b
+
+    flipped = flip(sub)
+    assert sub(5, 2) == THREE
+    assert flipped(5, 2) == -THREE

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fptk.iter.lazy import chunk, filter_iter, group_by_key, map_iter
+
+
+def test_map_filter_chunk() -> None:
+    xs = [1, 2, 3, 4, 5]
+    assert list(map_iter(lambda x: x * 2, xs)) == [2, 4, 6, 8, 10]
+    assert list(filter_iter(lambda x: x % 2 == 0, xs)) == [2, 4]
+    assert list(chunk(xs, 2)) == [(1, 2), (3, 4), (5,)]
+
+
+def test_group_by_key_requires_sorted() -> None:
+    xs = sorted(["aa", "b", "ccc", "dd"], key=len)
+    groups = list(group_by_key(xs, key=len))
+    assert groups == [(1, ["b"]), (2, ["aa", "dd"]), (3, ["ccc"])]

--- a/tests/test_nelist.py
+++ b/tests/test_nelist.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from fptk.adt.nelist import NonEmptyList
+
+HEAD = "a"
+T1 = "b"
+T2 = "c"
+
+
+def test_iter_and_append() -> None:
+    nel1 = NonEmptyList(HEAD)
+    nel2 = nel1.append(T1)
+    nel3 = nel2.append(T2)
+
+    # Original remains unchanged (immutability), appended lists grow
+    assert list(nel1) == [HEAD]
+    assert list(nel2) == [HEAD, T1]
+    assert list(nel3) == [HEAD, T1, T2]
+
+
+def test_from_iter_constructor() -> None:
+    empty: Iterable[str] = []
+    assert NonEmptyList.from_iter(empty) is None
+
+    seq: Iterable[str] = [HEAD, T1, T2]
+    nel = NonEmptyList.from_iter(seq)
+    assert nel is not None
+    assert nel.head == HEAD
+    assert list(nel) == [HEAD, T1, T2]

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import cast
+
+from fptk.adt.option import NONE, Option, Some, from_nullable
+
+TEN = 10
+ZERO = 0
+
+
+def test_option_map_bind() -> None:
+    assert from_nullable("x").map(lambda s: s.upper()).is_some()
+    assert from_nullable(None).map(lambda s: s).is_none()
+
+    def to_int(s: str) -> Option[int]:
+        try:
+            return Some(int(s))
+        except ValueError:
+            return cast(Option[int], NONE)
+
+    assert Some("7").bind(to_int).is_some()
+    assert Some("x").bind(to_int).is_none()
+
+
+def test_get_or_iter() -> None:
+    assert Some(TEN).get_or(ZERO) == TEN
+    assert NONE.get_or(ZERO) == ZERO
+    assert list(Some("a").iter()) == ["a"]
+    assert list(NONE.iter()) == []

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fptk.adt.result import Err, Ok, Result
+
+
+def test_result_chain() -> None:
+    def parse(s: str) -> Result[int, str]:
+        try:
+            return Ok(int(s))
+        except ValueError:
+            return Err("not int")
+
+    def non_neg(x: int) -> Result[int, str]:
+        return Ok(x) if x >= 0 else Err("neg")
+
+    assert parse("5").bind(non_neg).map(lambda x: x * 2).is_ok()
+    assert parse("-1").bind(non_neg).is_err()
+    assert parse("x").is_err()
+
+
+def test_map_err_unwraps() -> None:
+    e: Result[int, str] = Err("boom").map_err(lambda s: s.upper())
+    assert e.is_err()
+    assert isinstance(e, Err)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fptk.adt.result import Err, Ok, Result
+from fptk.validate import validate_all
+
+
+def test_validate_all_accumulates() -> None:
+    def len_at_least(n: int) -> Callable[[str], Result[str, str]]:
+        def check(s: str) -> Result[str, str]:
+            return Ok(s) if len(s) >= n else Err(f"len<{n}")
+
+        return check
+
+    def has_digit(s: str) -> Result[str, str]:
+        return Ok(s) if any(c.isdigit() for c in s) else Err("no digit")
+
+    r1 = validate_all([len_at_least(8), has_digit], "abc")
+    assert r1.is_err()
+
+    r2 = validate_all([len_at_least(3), has_digit], "ab3")
+    assert r2.is_ok()


### PR DESCRIPTION
Summary

- Document core modules and tighten types, add focused tests, and reorganize docs. README is
rewritten for clarity, and the roadmap is split into docs/ROADMAP.md.

Key Changes

- adt/option: add module/class/method docstrings, all, PEP 695 generics; safe casts for NONE
cases.
- adt/result: add docs and all; PEP 695 generics; safe casts in combinators.
- adt/nelist: add docs and all; PEP 695 generics; simple immutable non-empty list API.
- adt/iter/lazy: add docs and all; improve chunk using itertools.islice (preserves None); PEP 695
function generics.
- validate: move validation helper to top-level module (fptk.validate), add docs and all;
accumulate errors using NonEmptyList; explicit Err narrowing (no type ignores).
- tests: add NonEmptyList tests; annotate validate/result tests for strict mypy; fix minor ruff
issues.
- tooling: align pre-commit mypy (v1.17.1) with pyproject config for consistent strict typing.
- docs: rewrite README with quick start, API overview, and dev guide; roadmap moved to docs/
ROADMAP.md.

Motivation

- Make the library approachable with small, well-documented surfaces and typed examples.
- Keep core modules minimal, explicit, and easy to compose.