### PR TITLE
Milestone 1 — Utilities & Niceties (v0.2.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Quality gates (lint, type, tests)
         run: make check
       - name: Coverage gate
-        run: pytest --cov=fptk --cov-report=term-missing --cov-fail-under=90
+        run: make coverage
       - name: Package validity (build + twine check)
         run: make build-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
       - name: Install dev deps (make)
         run: make install-dev
       - name: Quality gates (lint, type, tests)

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -17,12 +17,10 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
-      - name: Install build tool
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build sdist & wheel (Makefile)
-        run: make build
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist & wheel (uvx build)
+        run: uvx build
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,10 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'pyproject.toml'
-      - name: Install build tool
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build sdist & wheel (Makefile)
-        run: make build
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build sdist & wheel (uvx build)
+        run: uvx build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.7
+    rev: v0.12.9
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.17.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: local
+    hooks:
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        types: [python]
+        args: ["--filter-files"]
   - repo: https://github.com/psf/black
     rev: 25.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,5 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file", "pyproject.toml"]
+        files: ^src/
         additional_dependencies: []

--- a/Makefile
+++ b/Makefile
@@ -17,45 +17,45 @@ install-dev: ## Create/refresh dev env via uv (uses dependency-groups)
 	  echo "uv is required. Install from https://docs.astral.sh/uv/install/"; \
 	  exit 1; \
 	}
-	uv sync
+	uv sync --group dev
 
 format: ## Run formatters (isort, black) in-place
-	isort .
-	black .
+	uv run isort .
+	uv run black .
 
 lint: ## Lint (ruff) + check formatting (isort --check, black --check)
-	ruff check .
-	isort --check-only .
-	black --check .
+	uv run ruff check .
+	uv run isort --check-only .
+	uv run black --check .
 
 type: ## Static type checking
-	mypy src
+	uv run mypy src
 
 test: ## Run unit tests (quiet)
-	pytest -q
+	uv run pytest -q
 
 test-verbose: ## Run tests verbosely
-	pytest -vv
+	uv run pytest -vv
 
 coverage: ## Test coverage report
-	pytest --cov=$(PKG) --cov-report=term-missing
+	uv run pytest --cov=$(PKG) --cov-report=term-missing
 
 bench: ## Quick property/benchmark tests (if present)
-	pytest -q --benchmark-only
+	uv run pytest -q --benchmark-only
 
 check: lint type test ## Run all quality gates: lint, type, tests (CI-like)
 
 build: ## Build sdist and wheel (dist/)
-	$(PY) -m build
+	uv run -m build
 
 build-check: build ## Validate built artifacts with twine
-	twine check dist/*
+	uv run twine check dist/*
 
 precommit-install: ## Set up pre-commit hooks locally
-	pre-commit install
+	uv run pre-commit install
 
 precommit-run: ## Run all pre-commit hooks on the repo
-	pre-commit run --all-files
+	uv run pre-commit run --all-files
 
 clean: ## Clean caches and build artifacts
 	rm -rf build/ dist/ .pytest_cache/ .mypy_cache/ .ruff_cache/ *.egg-info

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test-verbose: ## Run tests verbosely
 	uv run pytest -vv
 
 coverage: ## Test coverage report
-	uv run pytest --cov=$(PKG) --cov-report=term-missing
+	uv run pytest --cov=$(PKG) --cov-report=term-missing --cov-fail-under=90
 
 bench: ## Quick property/benchmark tests (if present)
 	uv run pytest -q --benchmark-only

--- a/Makefile
+++ b/Makefile
@@ -10,65 +10,53 @@ SRC := src/$(PKG) tests
 ## Show available targets
 help:
 	@echo "Available targets:" && \
-	awk 'BEGIN {FS=":.*##"} /^[a-zA-Z0-9_.-]+:.*##/ { printf "  [36m%-22s[0m %s", $$1, $$2 }' $(MAKEFILE_LIST)
+	awk 'BEGIN {FS=":.*##"} /^[a-zA-Z0-9_.-]+:.*##/ { printf "  [36m%-22s[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-## Create/refresh dev environment and tools
-install-dev:
-	$(PY) -m pip install --upgrade pip
-	pip install -e .
-	pip install ruff black mypy pytest hypothesis pytest-benchmark pre-commit build twine pytest-cov
+install-dev: ## Create/refresh dev env via uv (uses dependency-groups)
+	@command -v uv >/dev/null 2>&1 || { \
+	  echo "uv is required. Install from https://docs.astral.sh/uv/install/"; \
+	  exit 1; \
+	}
+	uv sync -g dev
 
-## Run formatters (black) in-place
-format:
+format: ## Run formatters (black) in-place
 	black .
 
-## Lint (ruff) + check formatting (black --check)
-lint:
+lint: ## Lint (ruff) + check formatting (black --check)
 	ruff check .
 	black --check .
 
-## Static type checking
-Type:
+type: ## Static type checking
 	mypy src
 
-## Run unit tests (quiet)
-test:
+test: ## Run unit tests (quiet)
 	pytest -q
 
-## Run tests verbosely
-Test-verbose:
+test-verbose: ## Run tests verbosely
 	pytest -vv
 
-## Test coverage report
-coverage:
+coverage: ## Test coverage report
 	pytest --cov=$(PKG) --cov-report=term-missing
 
-## Quick property/benchmark tests (if present)
-bench:
+bench: ## Quick property/benchmark tests (if present)
 	pytest -q --benchmark-only
 
-## Run all quality gates: lint, type, tests (CI-like)
-check: lint Type test
+check: lint type test ## Run all quality gates: lint, type, tests (CI-like)
 
-## Build sdist and wheel (dist/)
-build:
+build: ## Build sdist and wheel (dist/)
 	$(PY) -m build
 
-## Validate built artifacts with twine
-build-check: build
+build-check: build ## Validate built artifacts with twine
 	twine check dist/*
 
-## Set up pre-commit hooks locally
-precommit-install:
+precommit-install: ## Set up pre-commit hooks locally
 	pre-commit install
 
-## Run all pre-commit hooks on the repo
-precommit-run:
+precommit-run: ## Run all pre-commit hooks on the repo
 	pre-commit run --all-files
 
-## Clean caches and build artifacts
-clean:
+clean: ## Clean caches and build artifacts
 	rm -rf build/ dist/ .pytest_cache/ .mypy_cache/ .ruff_cache/ *.egg-info
 	find . -name "__pycache__" -type d -exec rm -rf {} +
 
-.PHONY: help install-dev format lint Type test Test-verbose coverage bench check build build-check precommit-install precommit-run clean
+.PHONY: help install-dev format lint type test test-verbose coverage bench check build build-check precommit-install precommit-run clean

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install-dev: ## Create/refresh dev env via uv (uses dependency-groups)
 	  echo "uv is required. Install from https://docs.astral.sh/uv/install/"; \
 	  exit 1; \
 	}
-	uv sync -g dev
+	uv sync
 
 format: ## Run formatters (isort, black) in-place
 	isort .

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,13 @@ install-dev: ## Create/refresh dev env via uv (uses dependency-groups)
 	}
 	uv sync -g dev
 
-format: ## Run formatters (black) in-place
+format: ## Run formatters (isort, black) in-place
+	isort .
 	black .
 
-lint: ## Lint (ruff) + check formatting (black --check)
+lint: ## Lint (ruff) + check formatting (isort --check, black --check)
 	ruff check .
+	isort --check-only .
 	black --check .
 
 type: ## Static type checking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ lint.select = ["E", "F", "I", "UP", "B", "ANN", "PL"]
 line-length = 100
 target-version = ["py312"]
 
+[tool.isort]
+profile = "black"
+line_length = 100
+src_paths = ["src", "tests"]
+known_first_party = ["fptk"]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fptk"
-version = "0.1.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 description = "Pragmatic functional programming helpers for Python (pipe/compose/curry, Option/Result, lazy iterators, applicative validation)."
 readme = "README.md"
@@ -88,6 +88,9 @@ include = [
   "release-please-config.json",
   ".release-please-manifest.json",
 ]
+
+[tool.hatch.version]
+path = "src/fptk/__init__.py"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ Changelog = "https://github.com/mhbxyz/fptk/releases"
 line-length = 100
 target-version = "py312"
 lint.select = ["E", "F", "I", "UP", "B", "ANN", "PL"]
-lint.ignore = ["ANN101"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["ANN"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "build>=1.3.0",
     "hatchling>=1.27.0",
     "hypothesis>=6.138.2",
+    "isort>=6.0.1",
     "mypy>=1.17.1",
     "pre-commit>=4.3.0",
     "pytest>=8.4.1",

--- a/src/fptk/adt/nelist.py
+++ b/src/fptk/adt/nelist.py
@@ -41,12 +41,12 @@ class NonEmptyList[E]:
     head: E
     tail: tuple[E, ...] = ()
 
-    def __iter__(self) -> Iterator[E]:
+    def __iter__(self: NonEmptyList[E]) -> Iterator[E]:
         """Iterate from ``head`` through all elements in ``tail``."""
         yield self.head
         yield from self.tail
 
-    def append(self, e: E) -> NonEmptyList[E]:
+    def append(self: NonEmptyList[E], e: E) -> NonEmptyList[E]:
         """Return a new list with ``e`` appended at the end."""
         return NonEmptyList(self.head, self.tail + (e,))
 

--- a/src/fptk/adt/option.py
+++ b/src/fptk/adt/option.py
@@ -1,16 +1,30 @@
 """Option (Some/_None) — a lightweight optional type.
 
-This module provides a tiny, typed alternative to using ``None`` directly. The
-``Option[T]`` algebraic data type has two variants:
+Use ``Option`` when you want to make absence explicit instead of sprinkling
+``if x is None`` throughout your code. It shines at boundaries (parsing, lookups,
+config) and when composing transformations that may drop out early.
+
+The ``Option[T]`` algebraic data type has two variants:
 
 - ``Some(value)``: wraps a present value of type ``T``
 - ``_None`` (singleton ``NONE``): represents the absence of a value
 
-Core operations are ``map`` (transform the contained value), ``bind`` (monadic
-flat-map), ``get_or`` (provide a default), and ``iter`` (iterate over zero-or-one
-values). All variants are immutable and hashable.
+Everyday usage
+- ``map(f)`` transforms the value if present; otherwise does nothing.
+- ``bind(f)`` (aka ``and_then``) chains computations that themselves return
+  ``Option``; the first ``NONE`` short-circuits the chain.
+- ``get_or(default)`` unwraps with a fallback; ``or_else`` picks an alternative
+  ``Option`` (eager value or lazy thunk).
+- ``match(some, none)`` and ``iter()`` are simple ways to consume values.
+- ``to_result(err)`` turns missing values into typed errors for richer flows.
 
-Examples:
+Interop and practicality
+- ``Option`` pairs well with ``traverse`` helpers to work over collections.
+- Objects are immutable and hashable; equality is by contained value/variant.
+- No magic: these are tiny wrappers around explicit branching. There is minor
+  call overhead; avoid deep chains in hot loops.
+
+Quick examples
 
     >>> from fptk.adt.option import Some, NONE, from_nullable
     >>> Some(2).map(lambda x: x + 1).get_or(0)
@@ -19,6 +33,12 @@ Examples:
     0
     >>> from_nullable("x").bind(lambda s: Some(s.upper())).get_or("-")
     'X'
+    >>> NONE.or_else(lambda: Some(9))
+    Some(9)
+    >>> Some(2).to_result("e").is_ok()
+    True
+    >>> NONE.match(lambda x: x, lambda: "-")
+    '-'
 
 Prefer constructing options explicitly via ``Some``/``NONE`` or ``from_nullable``
 when turning ``T | None`` into ``Option[T]``.
@@ -30,6 +50,8 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import TypeVar, cast
 
+from fptk.adt.result import Err, Ok, Result
+
 __all__ = [
     "Option",
     "Some",
@@ -39,6 +61,7 @@ __all__ = [
 
 T = TypeVar("T")
 U = TypeVar("U")
+E = TypeVar("E")
 
 
 class Option[T]:
@@ -48,18 +71,18 @@ class Option[T]:
     provided combinators to transform and consume values without branching.
     """
 
-    def is_some(self) -> bool:
+    def is_some(self: Option[T]) -> bool:
         """Return ``True`` if this is ``Some``.
 
         Subclasses implement this; calling on the base type is not expected.
         """
         raise NotImplementedError
 
-    def is_none(self) -> bool:
+    def is_none(self: Option[T]) -> bool:
         """Return ``True`` if this is ``NONE`` (i.e., not ``Some``)."""
         return not self.is_some()
 
-    def map(self, f: Callable[[T], U]) -> Option[U]:
+    def map(self: Option[T], f: Callable[[T], U]) -> Option[U]:
         """Apply ``f`` to the contained value if ``Some``; otherwise ``NONE``.
 
         Mapping preserves the optional nature: ``Some(x).map(f)`` becomes
@@ -67,37 +90,59 @@ class Option[T]:
         """
         return Some(f(self.value)) if isinstance(self, Some) else cast(Option[U], NONE)
 
-    def bind(self, f: Callable[[T], Option[U]]) -> Option[U]:
+    def bind(self: Option[T], f: Callable[[T], Option[U]]) -> Option[U]:
         """Flat-map with ``f`` returning another ``Option``.
 
         Also known as ``and_then``/``flat_map``.
         """
         return f(self.value) if isinstance(self, Some) else cast(Option[U], NONE)
 
-    def get_or(self, default: U) -> T | U:
+    def get_or(self: Option[T], default: U) -> T | U:
         """Unwrap the value or return ``default`` if ``NONE``."""
         return self.value if isinstance(self, Some) else default
 
-    def iter(self) -> Iterator[T]:
+    def iter(self: Option[T]) -> Iterator[T]:
         """Iterate over zero-or-one items (``Some`` yields one element)."""
         if isinstance(self, Some):
             yield self.value
+
+    def or_else(self: Option[T], alt: Option[T] | Callable[[], Option[T]]) -> Option[T]:
+        """Return self if Some; otherwise the alternative Option (value or thunk)."""
+        if isinstance(self, Some):
+            return self
+        return alt() if callable(alt) else alt
+
+    def to_result(self: Option[T], err: E | Callable[[], E]) -> Result[T, E]:
+        """Convert Option[T] to Result[T, E] (Some -> Ok; NONE -> Err(err))."""
+        if isinstance(self, Some):
+            return Ok(self.value)
+        return Err(err()) if callable(err) else Err(err)
+
+    def match(self: Option[T], some: Callable[[T], U], none: Callable[[], U]) -> U:
+        """Pattern-match helper."""
+        return some(self.value) if isinstance(self, Some) else none()
 
 
 @dataclass(frozen=True, slots=True)
 class Some[T](Option[T]):
     value: T
 
-    def is_some(self) -> bool:
+    def is_some(self: Some[T]) -> bool:
         """``Some`` always reports presence of a value."""
         return True
+
+    def __repr__(self: Some[T]) -> str:  # nicer than dataclass default
+        return f"Some({self.value!r})"
 
 
 @dataclass(frozen=True, slots=True)
 class _None(Option[None]):
-    def is_some(self) -> bool:
+    def is_some(self: _None) -> bool:
         """``_None`` always reports absence of a value."""
         return False
+
+    def __repr__(self: _None) -> str:
+        return "NONE"
 
 
 NONE = _None()

--- a/src/fptk/adt/result.py
+++ b/src/fptk/adt/result.py
@@ -1,32 +1,57 @@
 """Result (Ok/Err) — success or failure with typed error.
 
+Use ``Result`` when you want to model recoverable failures without exceptions.
+It keeps error types explicit and composes cleanly across multiple steps, which
+is great for parsing, validation, I/O, and “railway‑oriented” flows.
+
 The ``Result[T, E]`` algebraic data type represents computations that may
 succeed with a value of type ``T`` or fail with an error of type ``E``:
 
 - ``Ok(value)``: success variant wrapping a value ``T``
 - ``Err(error)``: failure variant wrapping an error ``E``
 
-Combinators include ``map`` (transform success), ``bind`` (flat-map), and
-``map_err`` (transform error), allowing ergonomic composition without ``try``/``except``.
+Everyday usage
+- ``map(f)`` transforms the success value; errors pass through unchanged.
+- ``bind(f)`` (aka ``and_then``) chains computations that return ``Result``;
+  the first ``Err`` short‑circuits the chain.
+- ``map_err(f)`` transforms the error while preserving successes.
+- ``unwrap_or(default)``/``unwrap_or_else(f)`` provide safe fallbacks.
+- ``match(ok, err)`` is a straightforward way to consume success vs error.
 
-Examples:
+Interop and practicality
+- Pairs well with ``traverse_result`` helpers to work over collections.
+- Converting exceptions: wrap functions with ``try_catch`` from ``fptk.core.func``.
+- Prefer small error types (``str``, ``Enum``, lightweight dataclass) for clarity.
+- Instances are immutable and hashable; equality compares contained value/error.
+- There’s minor call overhead; avoid excessively deep chains in hot paths.
+
+Quick examples
 
     >>> from fptk.adt.result import Ok, Err
     >>> Ok(2).map(lambda x: x + 1)
-    Ok(value=3)
+    Ok(3)
     >>> Err("boom").map(lambda x: x + 1)
-    Err(error='boom')
+    Err('boom')
     >>> Ok("7").bind(lambda s: Ok(int(s)))
-    Ok(value=7)
+    Ok(7)
     >>> Err("boom").map_err(lambda s: s.upper())
-    Err(error='BOOM')
+    Err('BOOM')
+    >>> Err("e").unwrap_or(0)
+    0
+    >>> Ok(5).unwrap_or_else(lambda e: 0)
+    5
+    >>> Ok(2).match(lambda x: x * 2, lambda e: 0)
+    4
+    >>> from fptk.core.func import try_catch
+    >>> try_catch(lambda: int("7"))()
+    Ok(7)
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TypeVar, cast
+from typing import cast
 
 __all__ = [
     "Result",
@@ -34,39 +59,47 @@ __all__ = [
     "Err",
 ]
 
-T = TypeVar("T")
-E = TypeVar("E")
-U = TypeVar("U")
-
 
 class Result[T, E]:
     """Computation that may succeed (``Ok``) or fail (``Err``)."""
 
-    def is_ok(self) -> bool:
+    def is_ok(self: Result[T, E]) -> bool:
         """Return ``True`` if this is ``Ok``."""
         raise NotImplementedError
 
-    def is_err(self) -> bool:
+    def is_err(self: Result[T, E]) -> bool:
         """Return ``True`` if this is ``Err`` (not ``Ok``)."""
         return not self.is_ok()
 
-    def map(self, f: Callable[[T], U]) -> Result[U, E]:
+    def map[U](self: Result[T, E], f: Callable[[T], U]) -> Result[U, E]:
         """Transform the success value with ``f``; preserve errors.
 
         ``Ok(x).map(f)`` becomes ``Ok(f(x))``; ``Err(e)`` stays ``Err(e)``.
         """
         return Ok(f(self.value)) if isinstance(self, Ok) else cast(Result[U, E], self)
 
-    def bind(self, f: Callable[[T], Result[U, E]]) -> Result[U, E]:
+    def bind[U](self: Result[T, E], f: Callable[[T], Result[U, E]]) -> Result[U, E]:
         """Flat-map with ``f`` returning another ``Result``.
 
         Also known as ``and_then``/``flat_map``.
         """
         return f(self.value) if isinstance(self, Ok) else cast(Result[U, E], self)
 
-    def map_err(self, f: Callable[[E], U]) -> Result[T, U]:
+    def map_err[U](self: Result[T, E], f: Callable[[E], U]) -> Result[T, U]:
         """Transform the error with ``f``; preserve successes."""
         return Err(f(self.error)) if isinstance(self, Err) else cast(Result[T, U], self)
+
+    def unwrap_or[U](self: Result[T, E], default: U) -> T | U:
+        """Return inner value for Ok, else provided default."""
+        return self.value if isinstance(self, Ok) else default
+
+    def unwrap_or_else[U](self: Result[T, E], f: Callable[[E], U]) -> T | U:
+        """Return inner value for Ok, else compute default from error."""
+        return self.value if isinstance(self, Ok) else f(cast(Err[T, E], self).error)
+
+    def match[U](self: Result[T, E], ok: Callable[[T], U], err: Callable[[E], U]) -> U:
+        """Pattern-match helper."""
+        return ok(self.value) if isinstance(self, Ok) else err(cast(Err[T, E], self).error)
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,8 +108,11 @@ class Ok[T, E](Result[T, E]):
 
     value: T
 
-    def is_ok(self) -> bool:
+    def is_ok(self: Ok[T, E]) -> bool:
         return True
+
+    def __repr__(self: Ok[T, E]) -> str:
+        return f"Ok({self.value!r})"
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,5 +121,8 @@ class Err[T, E](Result[T, E]):
 
     error: E
 
-    def is_ok(self) -> bool:
+    def is_ok(self: Err[T, E]) -> bool:
         return False
+
+    def __repr__(self: Err[T, E]) -> str:
+        return f"Err({self.error!r})"

--- a/src/fptk/adt/traverse.py
+++ b/src/fptk/adt/traverse.py
@@ -5,9 +5,9 @@ preserving the first absence/error and avoiding manual loops and conditionals.
 
 What they do (all fail‑fast)
 - ``sequence_option(xs)``: collect ``Some`` values into ``Some[list]``; return
-  ``NONE`` on the first ``NONE``.
+  ``NOTHING`` on the first ``NOTHING``.
 - ``traverse_option(xs, f)``: map with ``f: A -> Option[B]`` and collect; short‑
-  circuits to ``NONE`` on the first missing value.
+  circuits to ``NOTHING`` on the first missing value.
 - ``sequence_result(xs)``: collect ``Ok`` values into ``Ok[list]``; return the
   first ``Err`` encountered.
 - ``traverse_result(xs, f)``: map with ``f: A -> Result[B, E]`` and collect;
@@ -21,15 +21,15 @@ Practical notes
 
 Quick examples
 
-    >>> from fptk.adt.option import Some, NONE
+    >>> from fptk.adt.option import Some, NOTHING
     >>> sequence_option([Some(1), Some(2)])
     Some([1, 2])
-    >>> sequence_option([Some(1), NONE])
-    NONE
+    >>> sequence_option([Some(1), NOTHING])
+    NOTHING
     >>> traverse_option([1, 2, 3], lambda x: Some(x * 2))
     Some([2, 4, 6])
-    >>> traverse_option([1, 2, 3], lambda x: NONE if x == 2 else Some(x))
-    NONE
+    >>> traverse_option([1, 2, 3], lambda x: NOTHING if x == 2 else Some(x))
+    NOTHING
 
     >>> from fptk.adt.result import Ok, Err
     >>> sequence_result([Ok(1), Ok(2)])
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 
-from fptk.adt.option import NONE, Option, Some, _None
+from fptk.adt.option import NOTHING, Nothing, Option, Some
 from fptk.adt.result import Err, Ok, Result
 
 __all__ = [
@@ -57,26 +57,28 @@ __all__ = [
 ]
 
 
-def sequence_option[A](xs: Iterable[Option[A]]) -> Option[list[A]] | _None:
-    """Convert Iterable[Option[A]] -> Option[list[A]] (NONE if any item is NONE)."""
+def sequence_option[A](xs: Iterable[Option[A]]) -> Option[list[A]] | Nothing:
+    """Convert Iterable[Option[A]] -> Option[list[A]] (NOTHING if any item is NOTHING)."""
     out: list[A] = []
     for x in xs:
         if isinstance(x, Some):
             out.append(x.value)
         else:
-            return NONE
+            return NOTHING
     return Some(out)
 
 
-def traverse_option[A, B](xs: Iterable[A], f: Callable[[A], Option[B]]) -> Option[list[B]] | _None:
-    """Map with f and sequence (fail on first NONE)."""
+def traverse_option[A, B](
+    xs: Iterable[A], f: Callable[[A], Option[B]]
+) -> Option[list[B]] | Nothing:
+    """Map with f and sequence (fail on first NOTHING)."""
     out: list[B] = []
     for x in xs:
         ox = f(x)
         if isinstance(ox, Some):
             out.append(ox.value)
         else:
-            return NONE
+            return NOTHING
     return Some(out)
 
 

--- a/src/fptk/adt/traverse.py
+++ b/src/fptk/adt/traverse.py
@@ -1,0 +1,107 @@
+"""Sequence/traverse utilities for ``Option`` and ``Result``.
+
+Use these when you want to turn many small computations into one outcome,
+preserving the first absence/error and avoiding manual loops and conditionals.
+
+What they do (all fail‑fast)
+- ``sequence_option(xs)``: collect ``Some`` values into ``Some[list]``; return
+  ``NONE`` on the first ``NONE``.
+- ``traverse_option(xs, f)``: map with ``f: A -> Option[B]`` and collect; short‑
+  circuits to ``NONE`` on the first missing value.
+- ``sequence_result(xs)``: collect ``Ok`` values into ``Ok[list]``; return the
+  first ``Err`` encountered.
+- ``traverse_result(xs, f)``: map with ``f: A -> Result[B, E]`` and collect;
+  short‑circuits on the first ``Err``.
+
+Practical notes
+- Order is preserved; processing stops immediately on the first failure/absence.
+- Prefer ``traverse_*`` when mapping with a function that already returns an ADT.
+- These helpers compose nicely with ``Option``/``Result`` methods and keep
+  “happy path” linear and readable.
+
+Quick examples
+
+    >>> from fptk.adt.option import Some, NONE
+    >>> sequence_option([Some(1), Some(2)])
+    Some([1, 2])
+    >>> sequence_option([Some(1), NONE])
+    NONE
+    >>> traverse_option([1, 2, 3], lambda x: Some(x * 2))
+    Some([2, 4, 6])
+    >>> traverse_option([1, 2, 3], lambda x: NONE if x == 2 else Some(x))
+    NONE
+
+    >>> from fptk.adt.result import Ok, Err
+    >>> sequence_result([Ok(1), Ok(2)])
+    Ok([1, 2])
+    >>> sequence_result([Ok(1), Err('e')])
+    Err('e')
+    >>> traverse_result([1, 2, 3], lambda x: Ok(x * 2))
+    Ok([2, 4, 6])
+    >>> traverse_result([1, 2, 3], lambda x: Err('boom') if x == 2 else Ok(x))
+    Err('boom')
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+from fptk.adt.option import NONE, Option, Some, _None
+from fptk.adt.result import Err, Ok, Result
+
+__all__ = [
+    "sequence_option",
+    "traverse_option",
+    "sequence_result",
+    "traverse_result",
+]
+
+
+def sequence_option[A](xs: Iterable[Option[A]]) -> Option[list[A]] | _None:
+    """Convert Iterable[Option[A]] -> Option[list[A]] (NONE if any item is NONE)."""
+    out: list[A] = []
+    for x in xs:
+        if isinstance(x, Some):
+            out.append(x.value)
+        else:
+            return NONE
+    return Some(out)
+
+
+def traverse_option[A, B](xs: Iterable[A], f: Callable[[A], Option[B]]) -> Option[list[B]] | _None:
+    """Map with f and sequence (fail on first NONE)."""
+    out: list[B] = []
+    for x in xs:
+        ox = f(x)
+        if isinstance(ox, Some):
+            out.append(ox.value)
+        else:
+            return NONE
+    return Some(out)
+
+
+def sequence_result[A, E](xs: Iterable[Result[A, E]]) -> Result[list[A], E]:
+    """Convert Iterable[Result[A, E]] -> Result[list[A], E] (fail-fast on first Err)."""
+    out: list[A] = []
+    for x in xs:
+        if isinstance(x, Ok):
+            out.append(x.value)
+        elif isinstance(x, Err):
+            return Err(x.error)
+        else:  # pragma: no cover - unreachable with current Result variants
+            raise TypeError("Unexpected Result variant")
+    return Ok(out)
+
+
+def traverse_result[A, B, E](xs: Iterable[A], f: Callable[[A], Result[B, E]]) -> Result[list[B], E]:
+    """Map with f and sequence (fail-fast)."""
+    out: list[B] = []
+    for x in xs:
+        rx = f(x)
+        if isinstance(rx, Ok):
+            out.append(rx.value)
+        elif isinstance(rx, Err):
+            return Err(rx.error)
+        else:  # pragma: no cover - unreachable with current Result variants
+            raise TypeError("Unexpected Result variant")
+    return Ok(out)

--- a/src/fptk/core/func.py
+++ b/src/fptk/core/func.py
@@ -1,31 +1,66 @@
-"""Core function combinators: compose, pipe, curry, flip, tap, thunk.
+"""Core function combinators for small, pragmatic functional programming.
 
-These helpers provide small, pragmatic building blocks for a functional style.
+These helpers are lightweight glue for everyday Python: make pipelines readable,
+shape functions to better fit higher-order APIs, and keep side effects explicit.
+They are tiny wrappers around plain callables — no metaprogramming or magic.
 
-- ``compose(f, g)``: build a new function ``x -> f(g(x))``
-- ``pipe(x, *fs)``: thread a value through a sequence of unary functions
-- ``curry(fn)``: turn an N-arg function into nested unary functions
-- ``flip(fn)``: swap the first two arguments of a binary function
-- ``tap(f)``: run a side-effect on a value and return the value
-- ``thunk(f)``: memoized nullary function (simple lazy evaluation)
+What you’ll reach for most
+- ``pipe(x, *fs)``: prefer ``pipe(x, f, g, h)`` over nested calls ``h(g(f(x)))``.
+- ``compose(f, g)``: build small building blocks, then compose into handlers.
+- ``curry(fn)``: create unary-first variants so functions slot into maps/filters.
+- ``flip(fn)``: fix awkward argument order to enable partials or mapping.
+- ``tap(f)``: log/inspect/notify without breaking the data flow.
 
-Examples:
-    >>> from fptk.core.func import compose, pipe, curry, flip, tap, thunk
+Memoization and once-only
+- ``thunk(f)`` memoizes a zero-arg computation (simple, lazy value).
+- ``once(fn)`` runs a function at most once and returns the first result for all
+  future calls (ignores later arguments) — useful for setup hooks.
+
+Errors as values
+- ``try_catch(fn)`` converts exceptions into ``Result`` values (``Ok``/``Err``),
+  which pairs well with ``Result`` combinators and traverse helpers.
+
+Small utilities
+- ``identity(x)`` returns the input unchanged (handy default function).
+- ``const(x)`` ignores all arguments and returns ``x`` (useful in callbacks).
+
+Practical notes
+- These are convenience layers; Python call overhead is not zero. Keep chains
+  reasonable in hot paths.
+- ``curry`` counts positional parameters via ``__code__.co_argcount``. It works
+  for regular positional arguments; keyword-only and varargs are supported at
+  call time but aren’t part of the “enough arguments” check.
+
+Quick examples
+    >>> from fptk.core.func import (
+    ...     compose, pipe, curry, flip, tap, thunk,
+    ...     identity, const, once, try_catch,
+    ... )
     >>> pipe(2, lambda x: x + 1, lambda x: x * 3)
     9
-    >>> inc_then_double = compose(lambda x: x * 2, lambda x: x + 1)
-    >>> inc_then_double(3)
+    >>> compose(lambda x: x * 2, lambda x: x + 1)(3)
     8
     >>> add = lambda a, b: a + b
-    >>> add_curried = curry(add)
-    >>> add_curried(2)(3)
+    >>> curry(add)(2)(3)
     5
+    >>> tap(print)("hi")  # prints and returns the value
+    'hi'
+    >>> thunk(lambda: 42)()
+    42
+    >>> once(lambda x: x * 2)(3)
+    6
+    >>> const(7)("ignored", key="ignored")
+    7
+    >>> try_catch(lambda: 5)()
+    Ok(5)
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, ParamSpec, TypeVar
+from typing import Any
+
+from fptk.adt.result import Err, Ok, Result
 
 __all__ = [
     "compose",
@@ -34,15 +69,14 @@ __all__ = [
     "flip",
     "tap",
     "thunk",
+    "identity",
+    "const",
+    "once",
+    "try_catch",
 ]
 
-P = ParamSpec("P")
-T = TypeVar("T")
-U = TypeVar("U")
-V = TypeVar("V")
 
-
-def compose(f: Callable[[U], V], g: Callable[[T], U]) -> Callable[[T], V]:
+def compose[T, U, V](f: Callable[[U], V], g: Callable[[T], U]) -> Callable[[T], V]:
     """Compose two unary functions: (f ∘ g)(x) = f(g(x))."""
 
     def h(x: T) -> V:
@@ -51,7 +85,7 @@ def compose(f: Callable[[U], V], g: Callable[[T], U]) -> Callable[[T], V]:
     return h
 
 
-def pipe(x: T, *funcs: Callable[[Any], Any]) -> Any:  # noqa: ANN401, UP047
+def pipe[T](x: T, *funcs: Callable[[Any], Any]) -> Any:  # noqa: ANN401
     """Thread a value through a sequence of unary functions.
 
     Example: pipe(2, lambda x: x + 1, lambda x: x * 3) -> 9
@@ -61,7 +95,7 @@ def pipe(x: T, *funcs: Callable[[Any], Any]) -> Any:  # noqa: ANN401, UP047
     return x
 
 
-def curry(fn: Callable[P, T]) -> Callable[..., Any]:  # noqa: UP047
+def curry[T, **P](fn: Callable[P, T]) -> Callable[..., Any]:
     """Curry a function of N positional args into nested unary functions."""
 
     def curried(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
@@ -73,7 +107,7 @@ def curry(fn: Callable[P, T]) -> Callable[..., Any]:  # noqa: UP047
     return curried
 
 
-def flip(fn: Callable[[T, U], V]) -> Callable[[U, T], V]:  # noqa: UP047
+def flip[T, U, V](fn: Callable[[T, U], V]) -> Callable[[U, T], V]:
     """Flip the first two arguments of a binary function."""
 
     def flipped(b: U, a: T) -> V:
@@ -82,7 +116,7 @@ def flip(fn: Callable[[T, U], V]) -> Callable[[U, T], V]:  # noqa: UP047
     return flipped
 
 
-def tap(f: Callable[[T], Any]) -> Callable[[T], T]:  # noqa: UP047
+def tap[T](f: Callable[[T], Any]) -> Callable[[T], T]:
     """Run a side effect on a value and return the original value."""
 
     def inner(x: T) -> T:
@@ -92,16 +126,60 @@ def tap(f: Callable[[T], Any]) -> Callable[[T], T]:  # noqa: UP047
     return inner
 
 
-def thunk(f: Callable[[], T]) -> Callable[[], T]:  # noqa: UP047
+def thunk[T](f: Callable[[], T]) -> Callable[[], T | None]:
     """Memoized nullary function (simple lazy thunk)."""
     evaluated = False
     value: T | None = None
 
-    def wrapper() -> T:
+    def wrapper() -> T | None:
         nonlocal evaluated, value
         if not evaluated:
             value = f()
             evaluated = True
-        return value  # type: ignore[return-value]
+        return value
+
+    return wrapper
+
+
+def identity[T](x: T) -> T:
+    """Return the input unchanged."""
+    return x
+
+
+def const[T](x: T) -> Callable[..., T]:
+    """Return a function that ignores its arguments and returns x."""
+
+    def inner(*_: object, **__: object) -> T:
+        return x
+
+    return inner
+
+
+def once[T, **P](fn: Callable[P, T]) -> Callable[P, T | None]:
+    """Wrap fn so it runs at most once; memoize the first result."""
+    called = False
+    result: T | None = None
+
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T | None:
+        nonlocal called, result
+        if not called:
+            result = fn(*args, **kwargs)
+            called = True
+        return result
+
+    return wrapper
+
+
+def try_catch[T, **P](fn: Callable[P, T]) -> Callable[P, Result[T, Exception]]:
+    """Wrap fn to return Ok(...) or Err(Exception) instead of raising.
+
+    We catch Exception (not BaseException) to avoid swallowing KeyboardInterrupt/SystemExit.
+    """
+
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Result[T, Exception]:
+        try:
+            return Ok(fn(*args, **kwargs))
+        except Exception as e:  # noqa: BLE001
+            return Err(e)
 
     return wrapper

--- a/tests/test_laws.py
+++ b/tests/test_laws.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from fptk.adt.option import NONE, Option, Some, _None
+from fptk.adt.result import Err, Ok, Result
+
+# ---------- Option Functor + Monad laws ----------
+
+
+@st.composite
+def options(draw) -> Some | _None:
+    x = draw(st.integers())
+    return Some(x) if draw(st.booleans()) else NONE
+
+
+@given(options())
+def test_option_functor_identity(opt: Option[int]) -> None:
+    assert opt.map(lambda x: x) == opt
+
+
+@given(options(), st.integers())
+def test_option_functor_composition(opt: Option[int], k: int) -> None:
+    def f(x: int) -> int:
+        return x + 1
+
+    def g(x: int) -> int:
+        return x * (k % 5 + 1)
+
+    lhs = opt.map(lambda x: f(g(x)))
+    rhs = opt.map(g).map(f)
+    assert lhs == rhs
+
+
+def _of(x: int) -> Option[int]:
+    return Some(x)
+
+
+def _f(x: int) -> Option[int]:
+    return Some(x + 1) if (x % 3) != 0 else NONE
+
+
+def _g(x: int) -> Option[int]:
+    return Some(x * 2) if (x % 5) != 0 else NONE
+
+
+@given(st.integers())
+def test_option_monad_left_identity(x: int) -> None:
+    assert _of(x).bind(_f) == _f(x)
+
+
+@given(options())
+def test_option_monad_right_identity(m: Option[int]) -> None:
+    assert m.bind(_of) == m
+
+
+@given(options())
+def test_option_monad_associativity(m: Option[int]) -> None:
+    assert m.bind(_f).bind(_g) == m.bind(lambda x: _f(x).bind(_g))
+
+
+# ---------- Result Functor + Monad laws ----------
+
+
+@st.composite
+def results(draw) -> Ok | Err:
+    x = draw(st.integers())
+    if draw(st.booleans()):
+        return Ok(x)
+    return Err("e")
+
+
+@given(results())
+def test_result_functor_identity(res: Result[int, str]) -> None:
+    assert res.map(lambda x: x) == res
+
+
+@given(results(), st.integers())
+def test_result_functor_composition(res: Result[int, str], k: int) -> None:
+    def f(x: int) -> int:
+        return x + 1
+
+    def g(x: int) -> int:
+        return x * (k % 5 + 1)
+
+    lhs = res.map(lambda x: f(g(x)))
+    rhs = res.map(g).map(f)
+    assert lhs == rhs
+
+
+def of(x: int) -> Result[int, str]:
+    return Ok(x)
+
+
+def rf(x: int) -> Result[int, str]:
+    return Ok(x + 1) if (x % 3) != 0 else Err("f")
+
+
+def rg(x: int) -> Result[int, str]:
+    return Ok(x * 2) if (x % 5) != 0 else Err("g")
+
+
+@given(st.integers())
+def test_result_monad_left_identity(x: int) -> None:
+    assert of(x).bind(rf) == rf(x)
+
+
+@given(results())
+def test_result_monad_right_identity(m: Result[int, str]) -> None:
+    assert m.bind(of) == m if isinstance(m, Err) else of(m.value)
+
+
+@given(results())
+def test_result_monad_associativity(m: Result[int, str]) -> None:
+    assert m.bind(rf).bind(rg) == m.bind(lambda x: rf(x).bind(rg))

--- a/tests/test_laws.py
+++ b/tests/test_laws.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 from hypothesis import given
 from hypothesis import strategies as st
 
-from fptk.adt.option import NONE, Option, Some, _None
+from fptk.adt.option import NOTHING, Nothing, Option, Some
 from fptk.adt.result import Err, Ok, Result
 
 # ---------- Option Functor + Monad laws ----------
 
 
 @st.composite
-def options(draw) -> Some | _None:
+def options(draw) -> Some | Nothing:
     x = draw(st.integers())
-    return Some(x) if draw(st.booleans()) else NONE
+    return Some(x) if draw(st.booleans()) else NOTHING
 
 
 @given(options())
@@ -38,11 +38,11 @@ def _of(x: int) -> Option[int]:
 
 
 def _f(x: int) -> Option[int]:
-    return Some(x + 1) if (x % 3) != 0 else NONE
+    return Some(x + 1) if (x % 3) != 0 else NOTHING
 
 
 def _g(x: int) -> Option[int]:
-    return Some(x * 2) if (x % 5) != 0 else NONE
+    return Some(x * 2) if (x % 5) != 0 else NOTHING
 
 
 @given(st.integers())

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 from fptk.adt.option import NONE, Option, Some, from_nullable
+from fptk.adt.result import Err, Ok
 
 TEN = 10
 ZERO = 0
@@ -27,3 +28,19 @@ def test_get_or_iter() -> None:
     assert NONE.get_or(ZERO) == ZERO
     assert list(Some("a").iter()) == ["a"]
     assert list(NONE.iter()) == []
+
+
+def test_option_to_result_and_or_else_and_match() -> None:
+    assert Some(2).to_result("e") == Ok(2)
+    assert NONE.to_result(lambda: "e") == Err("e")
+
+    assert Some(1).or_else(Some(9)) == Some(1)
+    assert NONE.or_else(lambda: Some(9)) == Some(9)
+
+    assert Some("x").match(lambda s: s.upper(), lambda: "-") == "X"
+    assert NONE.match(lambda s: s, lambda: "-") == "-"
+
+
+def test_option_repr() -> None:
+    assert repr(Some(3)) == "Some(3)"
+    assert repr(NONE) == "NONE"

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import cast
 
-from fptk.adt.option import NONE, Option, Some, from_nullable
+from fptk.adt.option import NOTHING, Option, Some, from_nullable
 from fptk.adt.result import Err, Ok
 
 TEN = 10
@@ -17,7 +17,7 @@ def test_option_map_bind() -> None:
         try:
             return Some(int(s))
         except ValueError:
-            return cast(Option[int], NONE)
+            return cast(Option[int], NOTHING)
 
     assert Some("7").bind(to_int).is_some()
     assert Some("x").bind(to_int).is_none()
@@ -25,22 +25,22 @@ def test_option_map_bind() -> None:
 
 def test_get_or_iter() -> None:
     assert Some(TEN).get_or(ZERO) == TEN
-    assert NONE.get_or(ZERO) == ZERO
+    assert NOTHING.get_or(ZERO) == ZERO
     assert list(Some("a").iter()) == ["a"]
-    assert list(NONE.iter()) == []
+    assert list(NOTHING.iter()) == []
 
 
 def test_option_to_result_and_or_else_and_match() -> None:
     assert Some(2).to_result("e") == Ok(2)
-    assert NONE.to_result(lambda: "e") == Err("e")
+    assert NOTHING.to_result(lambda: "e") == Err("e")
 
     assert Some(1).or_else(Some(9)) == Some(1)
-    assert NONE.or_else(lambda: Some(9)) == Some(9)
+    assert NOTHING.or_else(lambda: Some(9)) == Some(9)
 
     assert Some("x").match(lambda s: s.upper(), lambda: "-") == "X"
-    assert NONE.match(lambda s: s, lambda: "-") == "-"
+    assert NOTHING.match(lambda s: s, lambda: "-") == "-"
 
 
 def test_option_repr() -> None:
     assert repr(Some(3)) == "Some(3)"
-    assert repr(NONE) == "NONE"
+    assert repr(NOTHING) == "NOTHING"

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from fptk.adt.result import Err, Ok, Result
 
+THREE = 3
+FOUR = 4
+ZERO = 0
+
 
 def test_result_chain() -> None:
     def parse(s: str) -> Result[int, str]:
@@ -22,3 +26,17 @@ def test_map_err_unwraps() -> None:
     e: Result[int, str] = Err("boom").map_err(lambda s: s.upper())
     assert e.is_err()
     assert isinstance(e, Err)
+
+
+def test_result_unwrap_and_match_and_repr() -> None:
+    assert Ok(THREE).unwrap_or(ZERO) == THREE
+    assert Err("e").unwrap_or(ZERO) == ZERO
+
+    assert Ok(THREE).unwrap_or_else(lambda e: ZERO) == THREE
+    assert Err("boom").unwrap_or_else(lambda e: len(e)) == FOUR
+
+    assert Ok("a").match(lambda s: s + "!", lambda e: "-") == "a!"
+    assert Err("x").match(lambda s: s, lambda e: e.upper()) == "X"
+
+    assert repr(Ok(1)) == "Ok(1)"
+    assert repr(Err("e")) == "Err('e')"

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from fptk.adt.option import NONE, Some
+from fptk.adt.result import Err, Ok
+from fptk.adt.traverse import (
+    sequence_option,
+    sequence_result,
+    traverse_option,
+    traverse_result,
+)
+
+ONE = 1
+TWO = 2
+THREE = 3
+FOUR = 4
+SIX = 6
+NINE = 9
+
+
+def test_sequence_option_and_result():
+    assert sequence_option([Some(ONE), Some(TWO)]) == Some([ONE, TWO])
+    assert sequence_option([Some(ONE), NONE]) is NONE
+
+    assert sequence_result([Ok(ONE), Ok(TWO)]) == Ok([ONE, TWO])
+    assert sequence_result([Ok(ONE), Err("e")]) == Err("e")
+
+
+def test_traverse_option_and_result():
+    assert traverse_option([ONE, TWO, THREE], lambda x: Some(x * TWO)) == Some([TWO, FOUR, SIX])
+    assert traverse_option([ONE, TWO, THREE], lambda x: NONE if x == TWO else Some(x)) is NONE
+
+    assert traverse_result([ONE, TWO, THREE], lambda x: Ok(x * THREE)) == Ok([THREE, SIX, NINE])
+    assert traverse_result([ONE, TWO, THREE], lambda x: Err("bad") if x == TWO else Ok(x)) == Err(
+        "bad"
+    )

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fptk.adt.option import NONE, Some
+from fptk.adt.option import NOTHING, Some
 from fptk.adt.result import Err, Ok
 from fptk.adt.traverse import (
     sequence_option,
@@ -19,7 +19,7 @@ NINE = 9
 
 def test_sequence_option_and_result():
     assert sequence_option([Some(ONE), Some(TWO)]) == Some([ONE, TWO])
-    assert sequence_option([Some(ONE), NONE]) is NONE
+    assert sequence_option([Some(ONE), NOTHING]) is NOTHING
 
     assert sequence_result([Ok(ONE), Ok(TWO)]) == Ok([ONE, TWO])
     assert sequence_result([Ok(ONE), Err("e")]) == Err("e")
@@ -27,7 +27,7 @@ def test_sequence_option_and_result():
 
 def test_traverse_option_and_result():
     assert traverse_option([ONE, TWO, THREE], lambda x: Some(x * TWO)) == Some([TWO, FOUR, SIX])
-    assert traverse_option([ONE, TWO, THREE], lambda x: NONE if x == TWO else Some(x)) is NONE
+    assert traverse_option([ONE, TWO, THREE], lambda x: NOTHING if x == TWO else Some(x)) is NOTHING
 
     assert traverse_result([ONE, TWO, THREE], lambda x: Ok(x * THREE)) == Ok([THREE, SIX, NINE])
     assert traverse_result([ONE, TWO, THREE], lambda x: Err("bad") if x == TWO else Ok(x)) == Err(

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,6 @@ wheels = [
 
 [[package]]
 name = "fptk"
-version = "0.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -286,6 +286,7 @@ dev = [
     { name = "build" },
     { name = "hatchling" },
     { name = "hypothesis" },
+    { name = "isort" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -303,6 +304,7 @@ dev = [
     { name = "build", specifier = ">=1.3.0" },
     { name = "hatchling", specifier = ">=1.27.0" },
     { name = "hypothesis", specifier = ">=6.138.2" },
+    { name = "isort", specifier = ">=6.0.1" },
     { name = "mypy", specifier = ">=1.17.1" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -377,6 +379,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
+name = "isort"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186 },
 ]
 
 [[package]]


### PR DESCRIPTION
Highlights
- BREAKING: Option emptiness renamed to Nothing/NOTHING (was _None/NONE).
- Core: new helpers (identity, const, once, try_catch) and PEP 695 typing.
- ADTs: Result adds unwrap_or/unwrap_or_else/match and concise reprs.
- Traverse: sequence_/traverse_ helpers for Option/Result (fail-fast).
- Tooling: isort integrated; pre-commit mypy limited to src.
- Build: dynamic version sourced from src/fptk/init.py.

Release

- Contains a breaking-change commit (feat(adt)! …), so release-please will bump to 0.2.0 on
main and open the release PR automatically.
- After merging this PR, merge the release PR to tag v0.2.0 and publish.
EOF

Notes

- release-please runs on pushes to main; it will open a “chore(main): release 0.2.0” PR
based on the conventional commits in develop (already pushed).
- Version drift is handled: packaging now reads the version from src/fptk/init.py.